### PR TITLE
Comply with vinyl.isVinyl check

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "readable-stream": "^1.0.27-1",
     "type-of-is": "^3.3.0",
     "util-deprecate": "^1.0.0",
-    "vinyl": "^0.2.3"
+    "vinyl": "^1.1.0"
   }
 }


### PR DESCRIPTION
https://github.com/gulpjs/vinyl/commit/0fe8da757a862bb956d88dec03ab6f99ca895f7f introduced a new function `vinyl.isVinyl` and suggests using that to check whether something is a vinyl file. And – surprise – the mock vinyl files are _not_ considered vinyl files, because it's still at vinyl version 0.2 which predates the 0.5.3 that introduced this functionality. Would be nice to update that, in order to better cooperate with the vinyl ecosystem all around.
