### PR TITLE
Compile CoffeeScript on prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A fake file system implementation, used for test code written based on vinyl and vinyl-fs. Including gulp plugins",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/gulp mocha"
+    "prepublish": "gulp coffee",
+    "test": "gulp mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This allows a simple “node install” to turn a git checkout into a usable copy.  This would be even more useful if npm/npm#3055 were dealt with.
